### PR TITLE
fix: correctly emit policy name when policy is resolved from cache

### DIFF
--- a/src/policy_authorizer.ts
+++ b/src/policy_authorizer.ts
@@ -135,7 +135,8 @@ export class PolicyAuthorizer<
      */
     if (KNOWN_POLICIES_CACHE.has(this.#policyImporter)) {
       debug('reading policy from the imports cache %O', this.#policyImporter)
-      return KNOWN_POLICIES_CACHE.get(this.#policyImporter)!
+      this.#policy = KNOWN_POLICIES_CACHE.get(this.#policyImporter)! as Policy
+      return this.#policy
     }
 
     /**

--- a/tests/bouncer/policies.spec.ts
+++ b/tests/bouncer/policies.spec.ts
@@ -620,6 +620,47 @@ test.group('Bouncer | policies', () => {
     assert.isFalse(canViewAll.authorized)
   })
 
+  test('emit correct policy name in event when policy is resolved from cache', async ({
+    assert,
+    cleanup,
+  }) => {
+    class User {
+      declare id: number
+      declare email: string
+    }
+
+    class PostPolicy extends BasePolicy {
+      view(_: User): AuthorizerResponse {
+        return true
+      }
+
+      viewAll(_: User): AuthorizerResponse {
+        return false
+      }
+    }
+
+    const events: { action: string }[] = []
+    const emitter = createEmitter()
+    const bouncer = new Bouncer(new User(), undefined, {
+      PostPolicy: async () => {
+        return { default: PostPolicy }
+      },
+    })
+    Bouncer.emitter = emitter
+    cleanup(() => (Bouncer.emitter = undefined))
+
+    emitter.on('authorization:finished', (event) => {
+      events.push({ action: event.action })
+    })
+
+    await bouncer.with('PostPolicy').execute('view')
+    await bouncer.with('PostPolicy').execute('viewAll')
+
+    assert.lengthOf(events, 2)
+    assert.equal(events[0].action, 'PostPolicy.view')
+    assert.equal(events[1].action, 'PostPolicy.viewAll')
+  })
+
   test('cache lazily imported policies', async ({ assert }) => {
     let importsCounter: number = 0
 


### PR DESCRIPTION
<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/adonisjs/.github/blob/main/docs/CONTRIBUTING.md
-->

### 🔗 Linked issue
#19 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

Fixes the issue in which a cached policy emits events with undefined policy names, e.g. `undefined.create`

This fix is a bit of a band-aid however - I've had to cast with `as Policy` as the `KNOWN_POLICIES_CACHE` type is set to a looser `Constructor<any>` than the class' generic `Policy extends Constructor<any>`

I attempted to work around this by moving some of the changes downstream and passing `policy` as an arg through the chain to `#emitAndRespond`, but that was introducing other issues leading to a larger refactor.

Resolves #19

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly. (N/A)
